### PR TITLE
Replace error with warning when tree = FALSE and serial is specified . 

### DIFF
--- a/R/simulate.r
+++ b/R/simulate.r
@@ -116,8 +116,9 @@ chain_sim <- function(n, offspring, stat = c("size", "length"), infinite = Inf,
             stop("The `serial` argument must be a function (see details in ?chain_sim()).")
         }
         if (!missing(tree) && tree == FALSE) {
-            stop("The `serial` argument can't be used with `tree==FALSE`.")
-        }
+            warning("`serial` can't be used with `tree = FALSE`; Setting `tree = TRUE` internally.")
+          tree <- TRUE
+          }
         tree <- TRUE
     } else if (!missing(tf)) {
         stop("The `tf` argument needs a `serial` argument.")


### PR DESCRIPTION
This PR seeks to address #16. This enhancement will hopefully improve user experience. 

In short, instead of an error, the user will now be warned that `tree` was set to `TRUE` because they *probably* mistakenly specified `tree=FALSE` with `serial` also specified. 