### PR TITLE
Adding contribution guide and issue and PR templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to bpmodels
+
+This outlines how to propose a change to bpmodels.
+
+## Making changes
+
+If you want to make a change, it's a good idea to first file an issue and make 
+sure someone from the team agrees that it’s needed.
+If you’ve found a bug, please file an issue that illustrates the bug with 
+a minimal [reprex](https://www.tidyverse.org/help/#reprex) (this will also 
+help you write a unit test, if needed). See [bug report template](../.github/ISSUE_TEMPLATE/bug_report.md). If you have a 
+feature request see [feature request](../.github/ISSUE_TEMPLATE/feature_request.md).
+
+### Pull request process
+
+See [pull request template](../.github/PULL_REQUEST_TEMPLATE/pull_request_template.md)
+
+*   Fork the package and clone onto your computer. If you haven't done 
+this before, we recommend using `usethis::create_from_github("epiverse-trace/bpmodels", fork = TRUE)`.
+
+*   Install all development dependencies with `devtools::install_dev_deps()`, 
+and then make sure the package passes R CMD check by running `devtools::check()`. 
+    If R CMD check doesn't pass cleanly, it's a good idea to ask for 
+    help before continuing. 
+*   Create a Git branch for your pull request (PR). We recommend using `usethis::pr_init("brief-description-of-change")`.
+
+*   Make your changes, commit to git, and then create a PR by running `usethis::pr_push()`, and following the prompts in your browser.
+    The title of your PR should briefly describe the change.
+    The body of your PR should contain `Fixes #issue-number`.
+
+*  For user-facing changes, add a bullet to the top of `NEWS.md` (i.e. just 
+below the first header). Follow the style described in <https://style.tidyverse.org/news.html>.
+
+### Code style
+
+*   New code should follow the tidyverse [style guide](https://style.tidyverse.org). 
+    You can use the [styler](https://CRAN.R-project.org/package=styler) 
+    package to apply these styles, but please don't restyle code that has 
+    nothing to do with your PR.  
+
+*  We use [roxygen2](https://cran.r-project.org/package=roxygen2), with [Markdown syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd-formatting.html), for documentation.  
+
+*  We use [testthat](https://cran.r-project.org/package=testthat) for 
+unit tests. 
+   Contributions with test cases included are easier to accept.  
+
+## Code of Conduct
+
+Please note that `bpmodels` is released with a
+[Contributor Code of Conduct](https://github.com/epiverse-trace/.github/blob/main/CODE_OF_CONDUCT.md). By contributing to this
+project you agree to abide by its terms.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+  
+Please place an "x" in all the boxes that apply
+---------------------------------------------
+  
+- [ ] I have the most recent version of bpmodels and R
+- [ ] I have found a bug
+- [ ] I have a [reproducible example](http://reprex.tidyverse.org/articles/reprex-dos-and-donts.html)
+- [ ] I want to request a new feature
+
+--------
+  
+Please include a brief description of the problem with a code example:
+  
+```r
+# insert reprex here
+```
+
+---------

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+  
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. E.g., I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,25 @@
+* **Please check if the PR fulfils these requirements**
+  
+- [ ] I have read the CONTRIBUTING guidelines 
+- [ ] The commit message follows our guidelines
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features)
+
+
+* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+
+
+
+* **What is the current behaviour?** (You can also link to an open issue here)
+
+
+
+* **What is the new behaviour (if this is a feature change)?**
+  
+  
+  
+* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
+
+
+
+* **Other information**:

--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -42,6 +42,6 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add README.md man/figures/
+          git add README.md 
           git diff-index --quiet HEAD || git commit -m "Automatic readme update"
           git push origin || echo "No changes to push"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,10 +2,10 @@ Package: bpmodels
 Title: Analysing chain statistics using branching process models
 Version: 0.1.9999
 Authors@R: c(
-    person("Sebastian", "Funk", , "sebastian.funk@lshtm.ac.uk", role = c("aut", "cre")),
+    person("Sebastian", "Funk", , "sebastian.funk@lshtm.ac.uk", role = "aut"),
     person("Zhian N.", "Kamvar", , "zkamvar@gmail.com", role = "ctb"),
     person("Flavio", "Finger", , "flavio.finger@epicentre.msf.org", role = "aut"),
-    person("James M.", "Azam", , "james.azam@lshtm.ac.uk", role = "aut")
+    person("James M.", "Azam", , "james.azam@lshtm.ac.uk", role = c("aut", "cre"))
   )
 Description: Provides methods to analyse and simulate the size and length
     of branching processes with an arbitrary offspring distribution. These
@@ -13,7 +13,7 @@ Description: Provides methods to analyse and simulate the size and length
     or length of infectious disease outbreaks, as discussed in Farrington
     et al. (2003) <doi:10.1093/biostatistics/4.2.279>.
 License: MIT + file LICENSE
-URL: https://github.com/epiverse-trace/bpmodels
+URL: https://github.com/epiverse-trace/bpmodels, https://epiverse-trace.github.io/bpmodels/
 BugReports: https://github.com/epiverse-trace/bpmodels/issues
 Depends: 
     R (>= 3.0.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bpmodels
 Title: Analysing chain statistics using branching process models
-Version: 0.1.0
+Version: 0.1.9999
 Authors@R: c(
     person("Sebastian", "Funk", , "sebastian.funk@lshtm.ac.uk", role = c("aut", "cre")),
     person("Zhian N.", "Kamvar", , "zkamvar@gmail.com", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,10 +2,33 @@ Package: bpmodels
 Title: Analysing chain statistics using branching process models
 Version: 0.1.9999
 Authors@R: c(
-    person("Sebastian", "Funk", , "sebastian.funk@lshtm.ac.uk", role = "aut"),
-    person("Zhian N.", "Kamvar", , "zkamvar@gmail.com", role = "ctb"),
-    person("Flavio", "Finger", , "flavio.finger@epicentre.msf.org", role = "aut"),
-    person("James M.", "Azam", , "james.azam@lshtm.ac.uk", role = c("aut", "cre"))
+    person(
+    given = "Sebastian",
+    family = "Funk",
+    email = "sebastian.funk@lshtm.ac.uk",
+    role = "aut",
+    comment = c(ORCHID = "https://orcid.org/0000-0002-2842-3406")
+    ),
+    person(
+    given = "Zhian N.",
+    family = "Kamvar",
+    email = "zkamvar@gmail.com",
+    role = "ctb",
+    comment = c(ORCHID = "https://orcid.org/0000-0003-1458-7108")
+    ),
+    person(
+    given = "Flavio",
+    family = "Finger",
+    email = "flavio.finger@epicentre.msf.org",
+    role = "aut",
+    comment = c(ORCHID = "https://orcid.org/0000-0002-8613-5170")
+    ),
+    person(
+    given = "James M.",
+    family = "Azam",
+    email = "james.azam@lshtm.ac.uk",
+    role = c("aut", "cre"),
+    comment = c(ORCHID = "https://orcid.org/0000-0001-5782-7330"))
   )
 Description: Provides methods to analyse and simulate the size and length
     of branching processes with an arbitrary offspring distribution. These
@@ -15,9 +38,9 @@ Description: Provides methods to analyse and simulate the size and length
 License: MIT + file LICENSE
 URL: https://github.com/epiverse-trace/bpmodels, https://epiverse-trace.github.io/bpmodels/
 BugReports: https://github.com/epiverse-trace/bpmodels/issues
-Depends: 
+Depends:
     R (>= 3.0.0)
-Suggests: 
+Suggests:
     bookdown,
     covr,
     dplyr,
@@ -29,9 +52,10 @@ Suggests:
     testthat,
     truncdist,
     usethis
-VignetteBuilder: 
+Config/testthat/edition: 3
+VignetteBuilder:
     knitr
-Remotes: 
+Remotes:
     github::epiverse-trace/epiparameter
 Encoding: UTF-8
 LazyData: true

--- a/README.Rmd
+++ b/README.Rmd
@@ -191,7 +191,7 @@ To report a bug please open an [issue](https://github.com/epiverse-trace/bpmodel
 ## Contribute
 
 We welcome contributions to enhance the package's functionalities. If you 
-wish to do so, please follow the [package contributing guide](https://github.com/epiverse-trace/.github/blob/main/CONTRIBUTING.md).
+wish to do so, please follow the [package contributing guide](https://github.com/epiverse-trace/bpmodels/blob/main/.github/CONTRIBUTING.md).
 
 ## Code of conduct
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,15 +16,11 @@ knitr::opts_chunk$set(
 # _bpmodels_: Methods for analysing the size and length of chains from branching process models
 
 <!-- badges: start -->
-![CRAN/METACRAN](https://img.shields.io/cran/v/bpmodels)
 ![GitHub R package version](https://img.shields.io/github/r-package/v/epiverse-trace/bpmodels)
-![GitHub all releases](https://img.shields.io/github/downloads/epiverse-trace/bpmodels/total?style=flat)
-![GitHub issues](https://img.shields.io/github/issues/epiverse-trace/bpmodels)
 [![R-CMD-check](https://github.com/epiverse-trace/bpmodels/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/epiverse-trace/bpmodels/actions/workflows/R-CMD-check.yaml)
 [![codecov](https://codecov.io/github/epiverse-trace/bpmodels/branch/main/graphs/badge.svg)](https://codecov.io/github/epiverse-trace/bpmodels) 
 ![GitHub contributors](https://img.shields.io/github/contributors/epiverse-trace/bpmodels)
-![GitHub commit activity](https://img.shields.io/github/commit-activity/m/epiverse-trace/bpmodels)
-![GitHub](https://img.shields.io/github/license/epiverse-trace/bpmodels)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 <!-- badges: end -->
 
 ```{r setup, include=FALSE}

--- a/README.md
+++ b/README.md
@@ -3,20 +3,14 @@
 
 <!-- badges: start -->
 
-![CRAN/METACRAN](https://img.shields.io/cran/v/bpmodels) ![GitHub R
-package
+![GitHub R package
 version](https://img.shields.io/github/r-package/v/epiverse-trace/bpmodels)
-![GitHub all
-releases](https://img.shields.io/github/downloads/epiverse-trace/bpmodels/total?style=flat)
-![GitHub
-issues](https://img.shields.io/github/issues/epiverse-trace/bpmodels)
 [![R-CMD-check](https://github.com/epiverse-trace/bpmodels/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/epiverse-trace/bpmodels/actions/workflows/R-CMD-check.yaml)
 [![codecov](https://codecov.io/github/epiverse-trace/bpmodels/branch/main/graphs/badge.svg)](https://codecov.io/github/epiverse-trace/bpmodels)
 ![GitHub
 contributors](https://img.shields.io/github/contributors/epiverse-trace/bpmodels)
-![GitHub commit
-activity](https://img.shields.io/github/commit-activity/m/epiverse-trace/bpmodels)
-![GitHub](https://img.shields.io/github/license/epiverse-trace/bpmodels)
+[![License:
+MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 <!-- badges: end -->
 
 *bpmodels* is an R package to simulate and analyse the size and length
@@ -64,7 +58,7 @@ To do this, we run
 set.seed(13)
 chain_sizes <- c(1, 1, 4, 7) # example of observed chain sizes
 chain_ll(x = chain_sizes, offspring = "pois", stat = "size", lambda = 0.5)
-#> [1] -8.607196
+#> [1] -8.607
 ```
 
 The first argument of `chain_ll()` is the chain size (or length, in
@@ -106,8 +100,7 @@ chain_sizes <- c(1, 1, 4, 7) # example of observed chain sizes
 ll <- chain_ll(chain_sizes, "pois", "size", obs_prob = 0.3, lambda = 0.5,
                nsim_obs = 10)
 ll
-#>  [1] -26.54167 -23.26117 -24.33027 -20.80310 -30.76152 -26.46751 -23.79326
-#>  [8] -19.14490 -32.08875 -22.23401
+#>  [1] -26.54 -23.26 -24.33 -20.80 -30.76 -26.47 -23.79 -19.14 -32.09 -22.23
 ```
 
 This returns `10` likelihood values (because `nsim_obs = 10`), which can
@@ -177,13 +170,13 @@ chains_df <- chain_sim(
   infinite = 100, serial = serial_interval, tree = TRUE
 )
 head(chains_df)
-#>   n id ancestor generation       time
-#> 1 1  1       NA          1 0.00000000
-#> 2 2  1       NA          1 0.00000000
-#> 3 3  1       NA          1 0.00000000
-#> 4 4  1       NA          1 0.00000000
-#> 5 5  1       NA          1 0.00000000
-#> 6 1  2        1          2 0.04771887
+#>   n id ancestor generation    time
+#> 1 1  1       NA          1 0.00000
+#> 2 2  1       NA          1 0.00000
+#> 3 3  1       NA          1 0.00000
+#> 4 4  1       NA          1 0.00000
+#> 5 5  1       NA          1 0.00000
+#> 6 1  2        1          2 0.04772
 ```
 
 ## Package vignettes
@@ -202,7 +195,7 @@ To report a bug please open an
 
 We welcome contributions to enhance the package’s functionalities. If
 you wish to do so, please follow the [package contributing
-guide](https://github.com/epiverse-trace/.github/blob/main/CONTRIBUTING.md).
+guide](https://github.com/epiverse-trace/bpmodels/blob/main/.github/CONTRIBUTING.md).
 
 ## Code of conduct
 
@@ -218,7 +211,7 @@ citation("bpmodels")
 #> 
 #> To cite package 'bpmodels' in publications use:
 #> 
-#>   Funk S, Finger F, Azam J (????). _bpmodels: Analysing chain
+#>   Funk S, Finger F, Azam J (2023). _bpmodels: Analysing chain
 #>   statistics using branching process models_. R package version 0.1.0,
 #>   <https://github.com/epiverse-trace/bpmodels>.
 #> 
@@ -227,6 +220,7 @@ citation("bpmodels")
 #>   @Manual{,
 #>     title = {bpmodels: Analysing chain statistics using branching process models},
 #>     author = {Sebastian Funk and Flavio Finger and James M. Azam},
+#>     year = {2023},
 #>     note = {R package version 0.1.0},
 #>     url = {https://github.com/epiverse-trace/bpmodels},
 #>   }

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To do this, we run
 set.seed(13)
 chain_sizes <- c(1, 1, 4, 7) # example of observed chain sizes
 chain_ll(x = chain_sizes, offspring = "pois", stat = "size", lambda = 0.5)
-#> [1] -8.607
+#> [1] -8.607196
 ```
 
 The first argument of `chain_ll()` is the chain size (or length, in
@@ -100,7 +100,8 @@ chain_sizes <- c(1, 1, 4, 7) # example of observed chain sizes
 ll <- chain_ll(chain_sizes, "pois", "size", obs_prob = 0.3, lambda = 0.5,
                nsim_obs = 10)
 ll
-#>  [1] -26.54 -23.26 -24.33 -20.80 -30.76 -26.47 -23.79 -19.14 -32.09 -22.23
+#>  [1] -26.54167 -23.26117 -24.33027 -20.80310 -30.76152 -26.46751 -23.79326
+#>  [8] -19.14490 -32.08875 -22.23401
 ```
 
 This returns `10` likelihood values (because `nsim_obs = 10`), which can
@@ -170,13 +171,13 @@ chains_df <- chain_sim(
   infinite = 100, serial = serial_interval, tree = TRUE
 )
 head(chains_df)
-#>   n id ancestor generation    time
-#> 1 1  1       NA          1 0.00000
-#> 2 2  1       NA          1 0.00000
-#> 3 3  1       NA          1 0.00000
-#> 4 4  1       NA          1 0.00000
-#> 5 5  1       NA          1 0.00000
-#> 6 1  2        1          2 0.04772
+#>   n id ancestor generation       time
+#> 1 1  1       NA          1 0.00000000
+#> 2 2  1       NA          1 0.00000000
+#> 3 3  1       NA          1 0.00000000
+#> 4 4  1       NA          1 0.00000000
+#> 5 5  1       NA          1 0.00000000
+#> 6 1  2        1          2 0.04771887
 ```
 
 ## Package vignettes
@@ -212,8 +213,9 @@ citation("bpmodels")
 #> To cite package 'bpmodels' in publications use:
 #> 
 #>   Funk S, Finger F, Azam J (2023). _bpmodels: Analysing chain
-#>   statistics using branching process models_. R package version 0.1.0,
-#>   <https://github.com/epiverse-trace/bpmodels>.
+#>   statistics using branching process models_.
+#>   https://github.com/epiverse-trace/bpmodels,
+#>   https://epiverse-trace.github.io/bpmodels/.
 #> 
 #> A BibTeX entry for LaTeX users is
 #> 
@@ -221,7 +223,7 @@ citation("bpmodels")
 #>     title = {bpmodels: Analysing chain statistics using branching process models},
 #>     author = {Sebastian Funk and Flavio Finger and James M. Azam},
 #>     year = {2023},
-#>     note = {R package version 0.1.0},
-#>     url = {https://github.com/epiverse-trace/bpmodels},
+#>     note = {https://github.com/epiverse-trace/bpmodels,
+#> https://epiverse-trace.github.io/bpmodels/},
 #>   }
 ```

--- a/man/bpmodels-package.Rd
+++ b/man/bpmodels-package.Rd
@@ -12,22 +12,23 @@ Provides methods to analyse and simulate the size and length of branching proces
 Useful links:
 \itemize{
   \item \url{https://github.com/epiverse-trace/bpmodels}
+  \item \url{https://epiverse-trace.github.io/bpmodels/}
   \item Report bugs at \url{https://github.com/epiverse-trace/bpmodels/issues}
 }
 
 }
 \author{
-\strong{Maintainer}: Sebastian Funk \email{sebastian.funk@lshtm.ac.uk}
+\strong{Maintainer}: James M. Azam \email{james.azam@lshtm.ac.uk} (\href{https://orcid.org/0000-0001-5782-7330}{ORCID})
 
 Authors:
 \itemize{
-  \item Flavio Finger \email{flavio.finger@epicentre.msf.org}
-  \item James M. Azam \email{james.azam@lshtm.ac.uk}
+  \item Sebastian Funk \email{sebastian.funk@lshtm.ac.uk} (\href{https://orcid.org/0000-0002-2842-3406}{ORCID})
+  \item Flavio Finger \email{flavio.finger@epicentre.msf.org} (\href{https://orcid.org/0000-0002-8613-5170}{ORCID})
 }
 
 Other contributors:
 \itemize{
-  \item Zhian N. Kamvar \email{zkamvar@gmail.com} [contributor]
+  \item Zhian N. Kamvar \email{zkamvar@gmail.com} (\href{https://orcid.org/0000-0003-1458-7108}{ORCID}) [contributor]
 }
 
 }


### PR DESCRIPTION
- This PR seeks to add the Epiverse contributing guide and templates for submitting issues and pull requests. 

- Additionally, it reduces the number of badges and fixes an issue where the MIT license badge was not being picked up. 

- The package version listed in DESCRIPTION and news.md were mismatched, so this was resolved too ([532b1e7](https://github.com/epiverse-trace/bpmodels/pull/42/commits/532b1e760a6d3102301ba4dd33acadceeb34a91c)). 

- Lastly, package maintenance was assigned to @jamesmbaazam ([d0a8df6](https://github.com/epiverse-trace/bpmodels/pull/42/commits/d0a8df61af5d9d361ed0c565b06d84068e524441)).

Overall, this PR closes #30 and closes #33.