### PR TITLE
Replace error with warning in chain_sim()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ License: MIT + file LICENSE
 URL: https://github.com/epiverse-trace/bpmodels, https://epiverse-trace.github.io/bpmodels/
 BugReports: https://github.com/epiverse-trace/bpmodels/issues
 Depends:
-    R (>= 3.0.0)
+    R (>= 3.6.0)
 Suggests:
     bookdown,
     covr,

--- a/R/simulate.r
+++ b/R/simulate.r
@@ -142,8 +142,8 @@ chain_sim <- function(n, offspring, stat = c("size", "length"), infinite = Inf,
                           "Setting `tree = TRUE` internally."
                           )
                     )
-          tree <- TRUE
-          }
+      }
+    tree <- TRUE
   } else if (!missing(tf)) {
     stop("If `tf` is specified, `serial` must be specified too.")
   }

--- a/R/simulate.r
+++ b/R/simulate.r
@@ -136,10 +136,14 @@ chain_sim <- function(n, offspring, stat = c("size", "length"), infinite = Inf,
                  )
            )
     }
-    if (!missing(tree) && tree == FALSE) {
-      stop("If `serial` is specified, then `tree` cannot be set to `FALSE`.")
-    }
-    tree <- TRUE
+      if (!missing(tree) && isFALSE(tree)) {
+            warning(sprintf("%s %s",
+                            "`serial` can't be used with `tree = FALSE`;",
+                          "Setting `tree = TRUE` internally."
+                          )
+                    )
+          tree <- TRUE
+          }
   } else if (!missing(tf)) {
     stop("If `tf` is specified, `serial` must be specified too.")
   }

--- a/tests/testthat/tests-sim.r
+++ b/tests/testthat/tests-sim.r
@@ -41,15 +41,12 @@ test_that("Errors are thrown", {
   )
   expect_error(
     chain_sim(
-      n = 2, offspring = "pois", "size", lambda = 0.9,
-      serial = function(x) rpois(x, 0.9), tree = FALSE
-    ),
-    "If `serial` is specified, then `tree` cannot be set to `FALSE`."
-  )
-  expect_error(
-    chain_sim(
-      n = 2, offspring = "pois", "size", lambda = 0.9,
-      tf = 5, tree = FALSE
+      n = 2,
+      offspring = "pois",
+      "size",
+      lambda = 0.9,
+      tf = 5,
+      tree = FALSE
     ),
     "If `tf` is specified, `serial` must be specified too."
   )
@@ -160,5 +157,19 @@ test_that("warnings work as expected", {
       pop = 100
     ),
     "Argument 'disp_offspring' not used for poisson offspring distribution."
+  )
+  expect_warning(
+    chain_sim(
+      n = 2,
+      offspring = "pois",
+      "size",
+      lambda = 0.9,
+      serial = function(x) rpois(x, 0.9),
+      tree = FALSE
+    ),
+    sprintf("%s %s",
+            "`serial` can't be used with `tree = FALSE`;",
+            "Setting `tree = TRUE` internally."
+    )
   )
 })


### PR DESCRIPTION
This PR will cause a minor behaviour change in `chain_sim()` and bump up the R version to accommodate some new base R functions in use in the package. The PR does not fix any raised issues.

Previously, whenever the user specified the `serial` argument in `chain_sim()` but also set `tree = FALSE`, they would get an error. In this PR, we change this behaviour so that when this argument combination occurs, we change `tree` to `TRUE`, throw a warning to inform the user about what happened and continue the simulation.  

This new behaviour is intended to improve user experience, but if it causes any inconveniences or bugs, please feel free to open an issue.