### PR TITLE
Reset github linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-*.[Rr]md linguist-language=R
-*.md linguist-language=R
-vignettes/* linguist-documentation


### PR DESCRIPTION
This PR's title is self-explanatory. 

This change was previously necessary because Github linguist was miscalculating the language stats of this repository by indicating that it was majorly `.tex`, which is not the case. 

This issue was fixed in a previous PR (#66) and hence, this PR will reset linguist and fix #62.