### PR TITLE
Remove dependency of development packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,6 @@ Depends:
     R (>= 3.6.0)
 Suggests:
     bookdown,
-    covr,
     dplyr,
     epiparameter,
     ggplot2,
@@ -50,8 +49,7 @@ Suggests:
     lubridate,
     rmarkdown,
     testthat,
-    truncdist,
-    usethis
+    truncdist
 Config/testthat/edition: 3
 VignetteBuilder:
     knitr


### PR DESCRIPTION
The same way we don't include pkgdown in `Suggests`, we shouldn't include covr or usethis, which are only used as part of a user-invisible development process. This also removes some of the reverse dependency checking burden for these packages.