### PR TITLE
Correct comment in `chain_sim()` example 

### DIFF
--- a/R/simulate.r
+++ b/R/simulate.r
@@ -102,7 +102,8 @@
 #'   serial = serial_interval
 #' )
 #'
-#' # Specifying `serial` and `tree = FALSE` will throw an error
+#' # Specifying `serial` and `tree = FALSE` will throw a warning saying that
+#' # `tree` was set to `TRUE` internally.
 #' set.seed(123)
 #' \dontrun{
 #' try(chain_sim(

--- a/man/chain_sim.Rd
+++ b/man/chain_sim.Rd
@@ -133,7 +133,8 @@ chain_sim(
   serial = serial_interval
 )
 
-# Specifying `serial` and `tree = FALSE` will throw an error
+# Specifying `serial` and `tree = FALSE` will throw a warning saying that
+# `tree` was set to `TRUE` internally.
 set.seed(123)
 \dontrun{
 try(chain_sim(


### PR DESCRIPTION
This PR corrects a comment in the example of `chain_sim()` that says that an error is thrown when `serial` is set and `tree` 
 is also specified as `FALSE`. The comment now says that a warning is thrown. 

This PR closes #72.  