### PR TITLE
Clarify `chain_ll()` documentation

### DIFF
--- a/man/chain_ll.Rd
+++ b/man/chain_ll.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/likelihoods.R
 \name{chain_ll}
 \alias{chain_ll}
-\title{Calculate the likelihood for the outcome of a branching process}
+\title{Calculate the log-likelihood for the outcome of a branching process}
 \usage{
 chain_ll(
   x,
@@ -29,22 +29,24 @@ the R distribution function (e.g., "pois" for Poisson, where
 
 \item{infinite}{any chains of this size/length will be treated as infinite}
 
-\item{exclude}{any sizes/lengths to exclude from the likelihood calculation}
+\item{exclude}{any sizes/lengths to exclude from the log-likelihood
+calculation}
 
 \item{individual}{if TRUE, a vector of individual log-likelihood
 contributions will be returned rather than the sum}
 
-\item{nsim_obs}{number of simulations if the likelihood is to be
+\item{nsim_obs}{number of simulations if the log-likelihood is to be
 approximated for imperfect observations}
 
 \item{...}{parameters for the offspring distribution}
 }
 \value{
-likelihood, or vector of likelihoods (if \code{obs_prob} < 1), or
-a list of individual likelihood contributions (if \code{individual=TRUE})
+log-likelihood, or vector of log-likelihoods
+(if \code{obs_prob} < 1), or a list of individual log-likelihood
+contributions (if \code{individual=TRUE})
 }
 \description{
-Calculate the likelihood for the outcome of a branching process
+Calculate the log-likelihood for the outcome of a branching process
 }
 \examples{
 chain_sizes <- c(1, 1, 4, 7) # example of observed chain sizes

--- a/man/gborel_size_ll.Rd
+++ b/man/gborel_size_ll.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/likelihoods.R
 \name{gborel_size_ll}
 \alias{gborel_size_ll}
-\title{Likelihood of the size of chains with gamma-Borel offspring distribution}
+\title{Log-likelihood of the size of chains with gamma-Borel offspring distribution}
 \usage{
 gborel_size_ll(x, size, prob, mu)
 }
@@ -21,7 +21,7 @@ applications)}
 log-likelihood values
 }
 \description{
-Likelihood of the size of chains with gamma-Borel offspring distribution
+Log-likelihood of the size of chains with gamma-Borel offspring distribution
 }
 \author{
 Sebastian Funk

--- a/man/geom_length_ll.Rd
+++ b/man/geom_length_ll.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/likelihoods.R
 \name{geom_length_ll}
 \alias{geom_length_ll}
-\title{Likelihood of the length of chains with geometric offspring distribution}
+\title{Log-likelihood of the length of chains with geometric offspring distribution}
 \usage{
 geom_length_ll(x, prob)
 }
@@ -16,7 +16,7 @@ geom_length_ll(x, prob)
 log-likelihood values
 }
 \description{
-Likelihood of the length of chains with geometric offspring distribution
+Log-likelihood of the length of chains with geometric offspring distribution
 }
 \author{
 Sebastian Funk

--- a/man/nbinom_size_ll.Rd
+++ b/man/nbinom_size_ll.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/likelihoods.R
 \name{nbinom_size_ll}
 \alias{nbinom_size_ll}
-\title{Likelihood of the size of chains with Negative-Binomial offspring
+\title{Log-likelihood of the size of chains with Negative-Binomial offspring
 distribution}
 \usage{
 nbinom_size_ll(x, size, prob, mu)
@@ -22,7 +22,7 @@ applications)}
 log-likelihood values
 }
 \description{
-Likelihood of the size of chains with Negative-Binomial offspring
+Log-likelihood of the size of chains with Negative-Binomial offspring
 distribution
 }
 \author{

--- a/man/offspring_ll.Rd
+++ b/man/offspring_ll.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/likelihoods.R
 \name{offspring_ll}
 \alias{offspring_ll}
-\title{Likelihood of the length of chains with generic offspring distribution}
+\title{Log-likelihood of the length of chains with generic offspring distribution}
 \usage{
 offspring_ll(x, offspring, stat, nsim_offspring = 100, ...)
 }

--- a/man/pois_length_ll.Rd
+++ b/man/pois_length_ll.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/likelihoods.R
 \name{pois_length_ll}
 \alias{pois_length_ll}
-\title{Likelihood of the length of chains with Poisson offspring distribution}
+\title{Log-likelihood of the length of chains with Poisson offspring distribution}
 \usage{
 pois_length_ll(x, lambda)
 }
@@ -15,7 +15,7 @@ pois_length_ll(x, lambda)
 log-likelihood values
 }
 \description{
-Likelihood of the length of chains with Poisson offspring distribution
+Log-likelihood of the length of chains with Poisson offspring distribution
 }
 \author{
 Sebastian Funk

--- a/man/pois_size_ll.Rd
+++ b/man/pois_size_ll.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/likelihoods.R
 \name{pois_size_ll}
 \alias{pois_size_ll}
-\title{Likelihood of the size of chains with Poisson offspring distribution}
+\title{Log-likelihood of the size of chains with Poisson offspring distribution}
 \usage{
 pois_size_ll(x, lambda)
 }
@@ -15,7 +15,7 @@ pois_size_ll(x, lambda)
 log-likelihood values
 }
 \description{
-Likelihood of the size of chains with Poisson offspring distribution
+Log-likelihood of the size of chains with Poisson offspring distribution
 }
 \author{
 Sebastian Funk


### PR DESCRIPTION
This PR seeks to clarify the documentation of `chain_ll()` so that it states that the function is used to estimate log-likelihoods, not likelihoods. All occurrences of "likelihood" have been replaced with "log-likelihood" in the documentation. 

This PR closes #73. 