### PR TITLE
Remove epiparameter from vignette and Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,6 @@ Depends:
 Suggests:
     bookdown,
     dplyr,
-    epiparameter,
     ggplot2,
     knitr,
     lubridate,
@@ -35,8 +34,6 @@ Suggests:
     truncdist
 VignetteBuilder:
     knitr
-Remotes:
-    github::epiverse-trace/epiparameter
 Config/Needs/website:epiverse-trace/epiversetheme
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/vignettes/projecting_incidence.Rmd
+++ b/vignettes/projecting_incidence.Rmd
@@ -116,7 +116,7 @@ SD [S] &= \sqrt {\ln \left(1 + \dfrac{\sigma^2}{\mu^2} \right)}
  
 \end{align}
 
-See [Wikipedia](https://en.wikipedia.org/wiki/Log-normal_distribution) for a 
+See ["log-normal_distribution" on Wikipedia](https://en.wikipedia.org/wiki/Log-normal_distribution) for a
 detailed explanation of this parametrisation.
 
 The [epiparameter](https://github.com/epiverse-trace/epiparameter) R package 

--- a/vignettes/projecting_incidence.Rmd
+++ b/vignettes/projecting_incidence.Rmd
@@ -47,7 +47,6 @@ library("bpmodels")
 library("dplyr")
 library("ggplot2")
 library("lubridate")
-library("epiparameter")
 ```
 
 ## Data
@@ -131,8 +130,8 @@ Let us set up the serial interval function with the appropriate inputs:
 mu <- 4.7
 sgma <- 2.9
 
-log_mean <- lnorm_meansd2meanlogsdlog(mu, sgma)[[1]]  # log mean
-log_sd <- lnorm_meansd2meanlogsdlog(mu, sgma)[[2]] # log sd
+log_mean <- log((mu^2) / (sqrt(sgma^2 + mu^2)))  # log mean
+log_sd <- sqrt(log(1 + (sgma / mu)^2)) # log sd
 
 #' serial interval function
 serial_interval <- function(sample_size) {

--- a/vignettes/projecting_incidence.Rmd
+++ b/vignettes/projecting_incidence.Rmd
@@ -118,14 +118,15 @@ SD [S] &= \sqrt {\ln \left(1 + \dfrac{\sigma^2}{\mu^2} \right)}
 See ["log-normal_distribution" on Wikipedia](https://en.wikipedia.org/wiki/Log-normal_distribution) for a
 detailed explanation of this parametrisation.
 
-The [epiparameter](https://github.com/epiverse-trace/epiparameter) R package 
-provides the function `epiparameter::lnorm_meansd2meanlogsdlog()` for implementing 
-this parametrisation. It takes as inputs the mean, $\mu$ and standard 
-deviation, $\sigma$ and returns a list with the transformed mean and 
-standard deviation. Refer to `?epiparameter::lnorm_meansd2meanlogsdlog` 
-for more details.
-
-Let us set up the serial interval function with the appropriate inputs:
+We will now set up the serial interval function with the appropriate inputs.
+We adopt R's random lognormal distribution generator (`rlnorm`) that
+takes `meanlog` and `sdlog` as arguments, which we define with the
+parametrisation above as `log_mean` and `log_sd` respectively and wrap it in 
+the `serial_interval` function. Moreover, `serial_interval` takes one
+argument `sample_size` as is required by `bpmodels` 
+(See `?bpmodels::chain_sim`), which is further passed to `rlnorm` as the 
+first argument to determine the number of observations to sample
+(See `?rlnorm`).
 ```{r input_prep3, message=FALSE}
 mu <- 4.7
 sgma <- 2.9


### PR DESCRIPTION
The CRAN policy does not allow any dependence on non-CRAN package. This PR removes `epiparameter` for this reason as it was used in one of the vignettes. When `epiparameter` goes on CRAN, we will revert to its usage. 

This PR closes #84. 