### PR TITLE
Combine theory and literature vignettes under one category on website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -37,12 +37,9 @@ reference:
 
 articles:
 - title: Background
-  navbar: Modelling
+  navbar: Theory & literature
   contents:
   - theoretical_background
-- title: Resources
-  navbar: Literature
-  contents:
   - branching_process_literature
 - title: Package vignettes
   navbar: Modelling

--- a/vignettes/branching_process_literature.Rmd
+++ b/vignettes/branching_process_literature.Rmd
@@ -18,12 +18,13 @@ nocite: '@*'
 ---
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE,
-                      message = FALSE,
-                      warning = FALSE,
-                      collapse = TRUE,
-                      comment = "#>"
-                      )
+knitr::opts_chunk$set(
+  echo = TRUE,
+  message = FALSE,
+  warning = FALSE,
+  collapse = TRUE,
+  comment = "#>"
+)
 ```
 
 Below, we provide a bibliography on the application of branching processes to 

--- a/vignettes/branching_process_literature.Rmd
+++ b/vignettes/branching_process_literature.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Literature on the applications of branching processes to infectious disease epidemiology"
+title: "Literature on branching process applications"
 output:
   bookdown::html_vignette2:
     fig_caption: yes
@@ -10,7 +10,7 @@ bibliography: branching_process_literature.json
 link-citations: true
 vignette: >
   %\VignetteEncoding{UTF-8}
-  %\VignetteIndexEntry{Literature on the applications of branching processes to infectious disease epidemiology}
+  %\VignetteIndexEntry{Literature on branching process applications}
   %\VignetteEngine{knitr::rmarkdown}
 editor_options: 
   chunk_output_type: console

--- a/vignettes/theoretical_background.Rmd
+++ b/vignettes/theoretical_background.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "An overview of the theoretical background for bpmodels"
+title: "Theoretical background for bpmodels"
 author: "Sebastian Funk and James Azam"
 output:
   bookdown::html_vignette2:
@@ -11,7 +11,7 @@ bibliography: references.json
 link-citations: true
 vignette: >
   %\VignetteEncoding{UTF-8}
-  %\VignetteIndexEntry{An overview of the theoretical background for bpmodels}
+  %\VignetteIndexEntry{Theoretical background for bpmodels}
   %\VignetteEngine{knitr::rmarkdown}
 editor_options:
   chunk_output_type: console


### PR DESCRIPTION
This PR fixes #137 by combining the theory and literature vignettes under one category on the website. Additionally, the vignette titles are shortened for easy reading.