### PR TITLE
Retire {bpmodels} and signpost to {epichains}

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,8 @@
+.onAttach <- function(libname, pkgname) {
+  packageStartupMessage(
+    "Note: bpmodels is now retired and replaced by epichains. ",
+    "All features from bpmodels are available in epichains. ",
+    "Get epichains from <https://github.com/epiverse-trace/epichains>.",
+    "Thank you for your support!"
+  )
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,12 +16,17 @@ knitr::opts_chunk$set(
 # _bpmodels_: Methods for simulating and analysing the size and length of transmission chains from branching process models
 
 <!-- badges: start -->
+[![Lifecycle: retired](https://img.shields.io/badge/lifecycle-retired-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#retired)
 ![GitHub R package version](https://img.shields.io/github/r-package/v/epiverse-trace/bpmodels)
 [![R-CMD-check](https://github.com/epiverse-trace/bpmodels/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/epiverse-trace/bpmodels/actions/workflows/R-CMD-check.yaml)
 [![codecov](https://codecov.io/github/epiverse-trace/bpmodels/branch/main/graph/badge.svg)](https://app.codecov.io/github/epiverse-trace/bpmodels) 
 ![GitHub contributors](https://img.shields.io/github/contributors/epiverse-trace/bpmodels)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/license/MIT/)
 <!-- badges: end -->
+
+## Note
+
+> `{bpmodels}` is now *retired and will no longer be maintained*. We recommend using [`{epichains}`](https://github.com/epiverse-trace/epichains) instead. If you need help converting your code to use `{epichains}`, please [open a discussion on epichains](https://github.com/epiverse-trace/epichains/discussions).
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 <!-- badges: start -->
 
+[![Lifecycle:
+retired](https://img.shields.io/badge/lifecycle-retired-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#retired)
 ![GitHub R package
 version](https://img.shields.io/github/r-package/v/epiverse-trace/bpmodels)
 [![R-CMD-check](https://github.com/epiverse-trace/bpmodels/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/epiverse-trace/bpmodels/actions/workflows/R-CMD-check.yaml)
@@ -12,6 +14,15 @@ contributors](https://img.shields.io/github/contributors/epiverse-trace/bpmodels
 [![License:
 MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/license/MIT/)
 <!-- badges: end -->
+
+## Note
+
+> `{bpmodels}` is now *retired and will no longer be maintained*. We
+> recommend using
+> [`{epichains}`](https://github.com/epiverse-trace/epichains) instead.
+> If you need help converting your code to use `{epichains}`, please
+> [open a discussion on
+> epichains](https://github.com/epiverse-trace/epichains/discussions).
 
 *bpmodels* is an R package to simulate and analyse the size and length
 of branching processes with a given offspring distribution. These models
@@ -35,6 +46,7 @@ To load the package, use
 
 ``` r
 library("bpmodels")
+#> Note: bpmodels is now retired and replaced by epichains. All features from bpmodels are available in epichains. Get epichains from <https://github.com/epiverse-trace/epichains>.Thank you for your support!
 ```
 
 # Core functionality


### PR DESCRIPTION
This PR adds a "retired" badge and a start message to notify the user that the package is retired.

The [epichains](https://github.com/epiverse-trace/epichains/) package replaces bpmodels, providing all its features and more: object orientation for interoperability with other packages in epicontacts, and S3 methods for summarising, aggregating, and plotting simulation results. The simulation functions in bpmodels are unified in epichains and allow for accounting for susceptible depletion and pre-existing immunity.
