### PR TITLE
Add retrement note to all vignettes

### DIFF
--- a/vignettes/bpmodels.Rmd
+++ b/vignettes/bpmodels.Rmd
@@ -17,6 +17,10 @@ editor_options:
   chunk_output_type: console
 ---
 
+# Note
+
+> `{bpmodels}` is now *retired and will no longer be maintained*. We recommend using [`{epichains}`](https://github.com/epiverse-trace/epichains) instead. If you need help converting your code to use `{epichains}`, please [open a discussion on epichains](https://github.com/epiverse-trace/epichains/discussions).
+
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE,
                       message = FALSE,

--- a/vignettes/branching_process_literature.Rmd
+++ b/vignettes/branching_process_literature.Rmd
@@ -17,6 +17,10 @@ editor_options:
 nocite: '@*'
 ---
 
+# Note
+
+> `{bpmodels}` is now *retired and will no longer be maintained*. We recommend using [`{epichains}`](https://github.com/epiverse-trace/epichains) instead. If you need help converting your code to use `{epichains}`, please [open a discussion on epichains](https://github.com/epiverse-trace/epichains/discussions).
+
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(
   echo = TRUE,

--- a/vignettes/projecting_incidence.Rmd
+++ b/vignettes/projecting_incidence.Rmd
@@ -10,12 +10,16 @@ pkgdown:
 bibliography: references.json
 link-citations: true
 vignette: >
-  %\VignetteIndexEntry{Projecting infectious disease incidence: a COVID-19 example}
   %\VignetteEncoding{UTF-8}
+  %\VignetteIndexEntry{Projecting infectious disease incidence: a COVID-19 example}
   %\VignetteEngine{knitr::rmarkdown}
 editor_options: 
   chunk_output_type: console
 ---
+
+# Note
+
+> `{bpmodels}` is now *retired and will no longer be maintained*. We recommend using [`{epichains}`](https://github.com/epiverse-trace/epichains) instead. If you need help converting your code to use `{epichains}`, please [open a discussion on epichains](https://github.com/epiverse-trace/epichains/discussions).
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(

--- a/vignettes/theoretical_background.Rmd
+++ b/vignettes/theoretical_background.Rmd
@@ -27,6 +27,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+# Note
+
+> `{bpmodels}` is now *retired and will no longer be maintained*. We recommend using [`{epichains}`](https://github.com/epiverse-trace/epichains) instead. If you need help converting your code to use `{epichains}`, please [open a discussion on epichains](https://github.com/epiverse-trace/epichains/discussions).
+
 _bpmodels_ provides methods to analyse and simulate the size and length of branching processes with an arbitrary offspring distribution.
 In this vignette we lay out the mathematical concepts behind the functionality available
 in the package.


### PR DESCRIPTION
This PR adds a note on the retirement of the package to all vignettes. This was an important step missed in #145.
