### PR TITLE
Fix wrong links in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -25,11 +25,9 @@ knitr::opts_chunk$set(
 <!-- badges: end -->
 
 
-<div style="background-color: #ffcccc; border: 1px solid #ff0000; padding: 10px; margin-bottom: 20px;">
-  <strong style="color: #ff0000;">️ WARNING:</strong>
-  <p style="margin: 0;">`{bpmodels}` is now *retired and will no longer be maintained*. We
-recommend using [`{epichains}`](https://github.com/epiverse-trace/epichains) instead. If you need help converting your code to use `{epichains}`, please [open a discussion on epichains](https://github.com/epiverse-trace/epichains/discussions).</p>
-</div>
+## WARNING
+
+> `{bpmodels}` is now *retired and will no longer be maintained*. We recommend using [`{epichains}`](https://github.com/epiverse-trace/epichains) instead. If you need help converting your code to use `{epichains}`, please [open a discussion on epichains](https://github.com/epiverse-trace/epichains/discussions).
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)

--- a/README.Rmd
+++ b/README.Rmd
@@ -28,7 +28,7 @@ knitr::opts_chunk$set(
 <div style="background-color: #ffcccc; border: 1px solid #ff0000; padding: 10px; margin-bottom: 20px;">
   <strong style="color: #ff0000;">️ WARNING:</strong>
   <p style="margin: 0;">`{bpmodels}` is now *retired and will no longer be maintained*. We
-recommend using [`{epichains}`](https://github.com/epiforecasts/epichains) instead. If you need help converting your code to use `{epichains}`, please [open a discussion on epichains](https://github.com/epiforecasts/epichains/discussions).</p>
+recommend using [`{epichains}`](https://github.com/epiverse-trace/epichains) instead. If you need help converting your code to use `{epichains}`, please [open a discussion on epichains](https://github.com/epiverse-trace/epichains/discussions).</p>
 </div>
 
 ```{r setup, include=FALSE}

--- a/README.md
+++ b/README.md
@@ -15,19 +15,14 @@ contributors](https://img.shields.io/github/contributors/epiforecasts/bpmodels)
 MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/license/MIT/)
 <!-- badges: end -->
 
-<div style="background-color: #ffcccc; border: 1px solid #ff0000; padding: 10px; margin-bottom: 20px;">
+## WARNING
 
-<strong style="color: #ff0000;">️ WARNING:</strong>
-<p style="margin: 0;">
-`{bpmodels}` is now *retired and will no longer be maintained*. We
-recommend using
-[`{epichains}`](https://github.com/epiverse-trace/epichains) instead. If
-you need help converting your code to use `{epichains}`, please [open a
-discussion on
-epichains](https://github.com/epiverse-trace/epichains/discussions).
-</p>
-
-</div>
+> `{bpmodels}` is now *retired and will no longer be maintained*. We
+> recommend using
+> [`{epichains}`](https://github.com/epiverse-trace/epichains) instead.
+> If you need help converting your code to use `{epichains}`, please
+> [open a discussion on
+> epichains](https://github.com/epiverse-trace/epichains/discussions).
 
 *bpmodels* is an R package to simulate and analyse the size and length
 of branching processes with a given offspring distribution. These models

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.or
 <p style="margin: 0;">
 `{bpmodels}` is now *retired and will no longer be maintained*. We
 recommend using
-[`{epichains}`](https://github.com/epiforecasts/epichains) instead. If
+[`{epichains}`](https://github.com/epiverse-trace/epichains) instead. If
 you need help converting your code to use `{epichains}`, please [open a
 discussion on
-epichains](https://github.com/epiforecasts/epichains/discussions).
+epichains](https://github.com/epiverse-trace/epichains/discussions).
 </p>
 
 </div>


### PR DESCRIPTION
A previous update to the README (#155) broke some links to epichains. This PR fixes that. This PR also replaces the HTML warning block with markdown because the former breaks the hyperlinks and doesn't offer additional benefits over the original setup as initially intended.